### PR TITLE
[ADD][T6982]Split-SO:split-sale-order-based-on-category-BAD-DAP

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
       - id: oca-fix-manifest-website
-        args: ["https://github.com/OCA/product-variant","https://bizzappdev.com"]
+        args: ["https://bizzappdev.com"]
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:

--- a/setup/.setuptools-odoo-make-default-ignore
+++ b/setup/.setuptools-odoo-make-default-ignore
@@ -1,0 +1,2 @@
+# addons listed in this file are ignored by
+# setuptools-odoo-make-default (one addon per line)

--- a/setup/README
+++ b/setup/README
@@ -1,0 +1,2 @@
+To learn more about this directory, please visit
+https://pypi.python.org/pypi/setuptools-odoo

--- a/setup/split_sale_order/odoo/addons/split_sale_order
+++ b/setup/split_sale_order/odoo/addons/split_sale_order
@@ -1,0 +1,1 @@
+../../../../split_sale_order

--- a/setup/split_sale_order/setup.py
+++ b/setup/split_sale_order/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/split_sale_order/README.rst
+++ b/split_sale_order/README.rst
@@ -1,0 +1,17 @@
+================
+Split Sale Order
+================
+
+Usage
+=====
+
+This Module is use for create sale order which have same product category.
+
+
+Credits
+=======
+
+Authors
+~~~~~~~
+
+* BizzAppDev Systems Pvt. Ltd

--- a/split_sale_order/__init__.py
+++ b/split_sale_order/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/split_sale_order/__manifest__.py
+++ b/split_sale_order/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "Split Sale Order",
+    "version": "15.0.0.0.1",
+    "category": "Sales Order",
+    "summary": "split sale order based on category",
+    "author": "BizzAppDev",
+    "website": "https://bizzappdev.com",
+    "depends": ["sale_management"],
+    "data": [
+        "security/ir.model.access.csv",
+        "wizard/sale_order_split_quotation_views.xml",
+        "views/sale_order_view.xml",
+    ],
+    "license": "Other proprietary",
+}

--- a/split_sale_order/models/__init__.py
+++ b/split_sale_order/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/split_sale_order/models/sale_order.py
+++ b/split_sale_order/models/sale_order.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    # field for set main sale order number #T6982
+    sale_order_reference = fields.Char(readonly=True)

--- a/split_sale_order/models/sale_order.py
+++ b/split_sale_order/models/sale_order.py
@@ -6,3 +6,10 @@ class SaleOrder(models.Model):
 
     # field for set main sale order number #T6982
     sale_order_reference = fields.Char(readonly=True)
+
+    def copy(self, default=None):
+        """Added copy method for set default single space on copied splited sale
+        order #T6982"""
+        default = dict(default or {})
+        default["sale_order_reference"] = " "
+        return super(SaleOrder, self).copy(default=default)

--- a/split_sale_order/security/ir.model.access.csv
+++ b/split_sale_order/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+split_sale_order.access_sale_order_split_quotation,access_sale_order_split_quotation,split_sale_order.model_sale_order_split_quotation,base.group_user,1,1,1,1

--- a/split_sale_order/views/sale_order_view.xml
+++ b/split_sale_order/views/sale_order_view.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- inherited view of sale #T6982-->
+    <record id="split_sale_order_form_view" model="ir.ui.view">
+        <field name="name">split.sale.order.form.view</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <!-- added button for split sale order wizard #T6982 -->
+            <xpath expr="//button[@name='payment_action_capture']" position="after">
+                <button
+                    name="%(split_sale_order.action_sale_order_split_quotation)d"
+                    type="action"
+                    string="Split Sale Order"
+                    class="oe_highlight"
+                    attrs="{'invisible': [('state', '!=', 'draft')]}"
+                />
+            </xpath>
+            <!-- added field for sale order reference #T6982 -->
+            <xpath expr="//field[@name='sale_order_template_id']" position="after">
+                <field name="sale_order_reference" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/split_sale_order/views/sale_order_view.xml
+++ b/split_sale_order/views/sale_order_view.xml
@@ -13,7 +13,7 @@
                     type="action"
                     string="Split Sale Order"
                     class="oe_highlight"
-                    attrs="{'invisible': [('state', '!=', 'draft')]}"
+                    attrs="{'invisible': ['|', '|', ('state', '=', 'sale'), ('state', '=', 'done'), ('state', '=', 'cancel')]}"
                 />
             </xpath>
             <!-- added field for sale order reference #T6982 -->

--- a/split_sale_order/wizard/__init__.py
+++ b/split_sale_order/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_split_quotation

--- a/split_sale_order/wizard/sale_order_split_quotation.py
+++ b/split_sale_order/wizard/sale_order_split_quotation.py
@@ -1,0 +1,90 @@
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
+
+
+class SaleOrderSplitQuotation(models.TransientModel):
+    _name = "sale.order.split.quotation"
+    _description = "Sale Order Split Quotation"
+
+    # fields for Sale Order Split Quotation wizard #T6982
+    split_sale_order = fields.Selection(
+        [
+            ("based_on_category", "Based on category"),
+            ("selected_lines", "Selected Lines"),
+            ("one_line_per_order", "One Line Per Order"),
+        ],
+        string="split sale order",
+    )
+    sale_order_line_ids = fields.Many2many(comodel_name="sale.order.line")
+
+    # action_split_sale_order for split sale order based on split sale order #T6982
+    def action_split_sale_order(self):
+        """this method is use for split sale order #T6982"""
+        sale_order = self._context.get("active_ids", [])
+        sale_order_id = self.env["sale.order"].search([("id", "=", sale_order)])
+
+        # for split_sale_order is based on category than this function will split
+        # sale order based on category #T6982
+        if self.split_sale_order == "based_on_category":
+            # this method split sale order based on category #T6982
+            if not sale_order_id.sale_order_reference:
+                if self.split_sale_order:
+                    product_category = []
+                    for product in sale_order_id.order_line:
+                        if product.product_id.categ_id.name not in product_category:
+                            product_category.append(product.product_id.categ_id.name)
+
+                    for category in product_category:
+                        product_list = [
+                            product.id
+                            for product in sale_order_id.order_line
+                            if category == product.product_id.categ_id.name
+                        ]
+
+                        self.env["sale.order"].create(
+                            {
+                                "partner_id": sale_order_id.partner_id.id,
+                                "sale_order_reference": sale_order_id.name,
+                                "order_line": product_list,
+                            }
+                        )
+                else:
+                    raise ValidationError(_("Please check the split sale order field"))
+
+            else:
+                raise ValidationError(_("This sale order is already splited"))
+
+        # for split_sale_order is selected line than it will create sale order of
+        # selected product #T6982
+        elif self.split_sale_order == "selected_lines":
+            # this method create sale order on selected product #T6982
+            if not sale_order_id.sale_order_reference:
+                for product in self.sale_order_line_ids:
+                    selected_product_list = [
+                        product.id for product in self.sale_order_line_ids
+                    ]
+                    self.env["sale.order"].create(
+                        {
+                            "partner_id": sale_order_id.partner_id.id,
+                            "sale_order_reference": sale_order_id.name,
+                            "order_line": selected_product_list,
+                        }
+                    )
+                    break
+            else:
+                raise ValidationError(_("This sale order is already splited"))
+
+        # for split_sale_order is one line  per order than this function is create new
+        # sale order for each product in sale order #T6982
+        elif self.split_sale_order == "one_line_per_order":
+            if not sale_order_id.sale_order_reference:
+                for product in sale_order_id.order_line:
+                    self.env["sale.order"].create(
+                        {
+                            "partner_id": sale_order_id.partner_id.id,
+                            "sale_order_reference": sale_order_id.name,
+                            "order_line": product,
+                        }
+                    )
+            else:
+                raise ValidationError(_("This sale order is already splited"))

--- a/split_sale_order/wizard/sale_order_split_quotation.py
+++ b/split_sale_order/wizard/sale_order_split_quotation.py
@@ -22,69 +22,105 @@ class SaleOrderSplitQuotation(models.TransientModel):
         """this method is use for split sale order #T6982"""
         sale_order = self._context.get("active_ids", [])
         sale_order_id = self.env["sale.order"].search([("id", "=", sale_order)])
-
         # for split_sale_order is based on category than this function will split
         # sale order based on category #T6982
-        if self.split_sale_order == "based_on_category":
-            # this method split sale order based on category #T6982
-            if not sale_order_id.sale_order_reference:
-                if self.split_sale_order:
-                    product_category = []
-                    for product in sale_order_id.order_line:
-                        if product.product_id.categ_id.name not in product_category:
-                            product_category.append(product.product_id.categ_id.name)
+        if len(sale_order_id.order_line) > 1:
+            if self.split_sale_order == "based_on_category":
+                # this method split sale order based on category #T6982
+                if not sale_order_id.sale_order_reference:
+                    if self.split_sale_order:
+                        product_category = []
+                        for product in sale_order_id.order_line:
+                            if product.product_id.categ_id.name not in product_category:
+                                product_category.append(
+                                    product.product_id.categ_id.name
+                                )
 
-                    for category in product_category:
-                        product_list = [
-                            product.id
-                            for product in sale_order_id.order_line
-                            if category == product.product_id.categ_id.name
+                        for category in product_category:
+                            product_list = [
+                                product.id
+                                for product in sale_order_id.order_line
+                                if category == product.product_id.categ_id.name
+                            ]
+
+                            self.env["sale.order"].create(
+                                {
+                                    "partner_id": sale_order_id.partner_id.id,
+                                    "sale_order_reference": sale_order_id.name,
+                                    "order_line": product_list,
+                                }
+                            )
+                    else:
+                        raise ValidationError(
+                            _("Please check the split sale order field")
+                        )
+
+                else:
+                    raise ValidationError(_("This sale order is already splited"))
+
+            # for split_sale_order is selected line than it will create sale order of
+            # selected product #T6982
+            elif self.split_sale_order == "selected_lines":
+                # this method create sale order on selected product #T6982
+                if not sale_order_id.sale_order_reference:
+                    for product in self.sale_order_line_ids:
+                        selected_product_list = [
+                            product.id for product in self.sale_order_line_ids
                         ]
-
                         self.env["sale.order"].create(
                             {
                                 "partner_id": sale_order_id.partner_id.id,
                                 "sale_order_reference": sale_order_id.name,
-                                "order_line": product_list,
+                                "order_line": selected_product_list,
+                            }
+                        )
+                        break
+                else:
+                    raise ValidationError(_("This sale order is already splited"))
+
+            # for split_sale_order is one line  per order than this function is create new
+            # sale order for each product in sale order #T6982
+            elif self.split_sale_order == "one_line_per_order":
+                if not sale_order_id.sale_order_reference:
+                    for product in sale_order_id.order_line:
+                        self.env["sale.order"].create(
+                            {
+                                "partner_id": sale_order_id.partner_id.id,
+                                "sale_order_reference": sale_order_id.name,
+                                "order_line": product,
                             }
                         )
                 else:
-                    raise ValidationError(_("Please check the split sale order field"))
+                    raise ValidationError(_("This sale order is already splited"))
 
-            else:
-                raise ValidationError(_("This sale order is already splited"))
+            # product list for splited order product #T6982
+            product_list = [
+                (order.order_line.product_id).ids
+                for order in self.env["sale.order"].search([])
+                if sale_order_id.name == order.sale_order_reference
+            ]
 
-        # for split_sale_order is selected line than it will create sale order of
-        # selected product #T6982
-        elif self.split_sale_order == "selected_lines":
-            # this method create sale order on selected product #T6982
-            if not sale_order_id.sale_order_reference:
-                for product in self.sale_order_line_ids:
-                    selected_product_list = [
-                        product.id for product in self.sale_order_line_ids
-                    ]
-                    self.env["sale.order"].create(
+            # added product to main sale order #T6982
+            for products in product_list:
+                for product in products:
+                    sale_order_id.update(
                         {
-                            "partner_id": sale_order_id.partner_id.id,
-                            "sale_order_reference": sale_order_id.name,
-                            "order_line": selected_product_list,
+                            "order_line": [
+                                (
+                                    0,
+                                    0,
+                                    {
+                                        "name": product,
+                                        "product_id": product,
+                                        "product_uom_qty": 1,
+                                        "price_unit": 1,
+                                    },
+                                ),
+                            ]
                         }
                     )
-                    break
-            else:
-                raise ValidationError(_("This sale order is already splited"))
 
-        # for split_sale_order is one line  per order than this function is create new
-        # sale order for each product in sale order #T6982
-        elif self.split_sale_order == "one_line_per_order":
-            if not sale_order_id.sale_order_reference:
-                for product in sale_order_id.order_line:
-                    self.env["sale.order"].create(
-                        {
-                            "partner_id": sale_order_id.partner_id.id,
-                            "sale_order_reference": sale_order_id.name,
-                            "order_line": product,
-                        }
-                    )
-            else:
-                raise ValidationError(_("This sale order is already splited"))
+        else:
+            raise ValidationError(
+                _("This sale order has only one order no need to split sale order")
+            )

--- a/split_sale_order/wizard/sale_order_split_quotation_views.xml
+++ b/split_sale_order/wizard/sale_order_split_quotation_views.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- sale_order_split_quotation wizard form view #T6982 -->
+    <record
+        model="ir.ui.view"
+        id="split_sale_order_sale_order_split_quotation_form_view"
+    >
+        <field name="name">split.sale.order.sale.order.split.quotation.form.view</field>
+        <field name="model">sale.order.split.quotation</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="split_sale_order" />
+                        </group>
+                    </group>
+                    <notebook
+                        attrs="{'invisible':[('split_sale_order','!=','selected_lines')] }"
+                    >
+                        <page string="Product Records" name="sale_order_notebook">
+                            <field name="sale_order_line_ids" />
+                        </page>
+                    </notebook>
+                    <footer>
+                        <button
+                            name="action_split_sale_order"
+                            string="Split Sale Order"
+                            class="btn-primary"
+                            type="object"
+                            data-hotkey="v"
+                        />
+                        <button
+                            string="Discard"
+                            class="btn-secondary"
+                            special="cancel"
+                            data-hotkey="z"
+                        />
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- sale_order_split_quotation wizard action window #T6982 -->
+    <record model="ir.actions.act_window" id="action_sale_order_split_quotation">
+        <field name="name">Split Sale Order</field>
+        <field name="res_model">sale.order.split.quotation</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
Model : split_sale_order

    -Add new button at header(split quotation) in sale order level(should be visible only in draft state)  

    -Create a new wizard([sale.order.split.quotation),]

    -having the following 
     fields: 

     1) options (selection field) : values (Based on category, Selected Lines, One Line Per Order)  

     2) sale_order_line_ids (m2m field) : should be visible if the options is set to 'Selected Lines'  

    *conditions
        - If we select "Based on Category" then all the order lines of current order should be split based on the product 
          category.  
        - If we select "Selected Lines" then based on selected lines on M2M the order will be splitter.  
        - If we select "One Line Per Order" then each order have one line.  

    -The Orders which are splitted must have the reference of the main SO